### PR TITLE
Master dev

### DIFF
--- a/mars_templates/amescap_profile
+++ b/mars_templates/amescap_profile
@@ -4,6 +4,7 @@
 <<<<<<<<<<<<<<| MarsPlot.py Settings |>>>>>>>>>>>>>
 add_sol_to_time_axis = False  # If True, displays sol numbers below Ls values on axis
 lon_coordinate = 360          # 180 for -180->180 or 360 for 0->360
+show_NaN_in_slice = False      # True includes NaNs in slices (like np.mean), False ignores NaNs (like np.nanmean)
 
 <<<<<<<<<<<<<<| Pressure definitions for pstd |>>>>>>>>>>>>>
 


### PR DESCRIPTION
Completed 3 MarsPlot user-customization preferences:
1. add_sol_to_time_axis in amescap_profile determines whether or not the sol number appears below Ls in the x or y axis label. Default: Ls label only.
3. show_NaN_in_slice in amescap_profile defines whether or not NaNs are included in calculations of zonal means. Default: ignore NaNs (np.nanmean).
4. lon_coordinate in amescap_profile sets the longitude axis range from -180 to 180 or 0-360. Default: 0-360.

add_sol_to_time_axis maps to add_sol_time_axis in MarsPlot.
show_NaN_in_slice maps to include_NaNs in MarsPlot.
lon_coordinate maps to lon_coord_type in MarsPlot.