### PR TITLE
fixed exceptions in MarsVars

### DIFF
--- a/amescap/Script_utils.py
+++ b/amescap/Script_utils.py
@@ -1451,6 +1451,15 @@ def except_message(debug,exception,varname,ifile,pre="",ext=""):
     :param varname: Name of variable causing exception
     :type varname: string
 
+    :param ifile: Name of input file
+    :type ifile: string
+
+    :param pre: Prefix to new variable
+    :type pre: string
+
+    :param ext: Extension to new variable
+    :type ext: string
+
     """
     if debug:
         raise

--- a/amescap/Script_utils.py
+++ b/amescap/Script_utils.py
@@ -1435,3 +1435,31 @@ def reset_FV3_names(MOD):
             name=ivar[4:] #if attribute is dim_lat, just get the 'lat' part
         setattr(MOD,ivar,name) #reset the original names
     return MOD
+
+def except_message(debug,exception,varname,ifile,pre="",ext=""):
+    """
+    This function prints an error message in the case of an exception.
+    It also contains a special error in the case of an already existing
+    variable.
+
+    :param debug: Flag for debug mode
+    :type debug: logical
+
+    :param exception: Exception from try statement
+    :type exception: class object
+
+    :param varname: Name of variable causing exception
+    :type varname: string
+
+    """
+    if debug:
+        raise
+    if str(exception)[0:35] == (
+        "NetCDF: String match to name in use"):
+        print(f"{Yellow}***Error*** Variable already "
+              f"exists in file.\nDelete the existing "
+              f"variable with "
+              f"``MarsVars {ifile} -rm "
+              f"{pre}{varname}{ext}``{Nclr}")
+    else:
+        print(f"{Red}***Error*** {str(exception)}")

--- a/bin/MarsVars.py
+++ b/bin/MarsVars.py
@@ -60,7 +60,7 @@ from amescap.FV3_utils import (
 )
 from amescap.Script_utils import (
     check_file_tape, FV3_file_type, filter_vars,
-    get_longname_unit, ak_bk_loader
+    get_longname_unit, ak_bk_loader, except_message
 )
 from amescap.Ncdf_wrapper import Ncdf
 
@@ -1638,15 +1638,7 @@ def main():
                       f"successfully ***{Nclr}")
 
             except Exception as exception:
-                if debug:
-                    raise
-                elif str(exception[0:35]) == (
-                    "NetCDF: String match to name in use"
-                    ):
-                    print(f"{Yellow}***Error*** Variable already "
-                          f"exists in file.\nDelete the existing "
-                          f"variable d_dz_{idiff} with MarsVars "
-                          f"``{ifile} -rm d_dz_{idiff}''{Nclr}")
+                except_message(debug,exception,ivar,ifile)
         # ==============================================================
         #                   Vertical Differentiation
         # ==============================================================
@@ -1737,15 +1729,7 @@ def main():
 
                     print(f"d_dz_{idiff}: {Green}Done{Nclr}")
                 except Exception as exception:
-                    if debug:
-                        raise
-                    if str(exception) == (
-                        "NetCDF: String match to name in use"
-                        ):
-                        print(f"{Yellow}***Error*** Variable already "
-                              f"exists in file.\nDelete the existing "
-                              f"variable d_dz_{idiff} with MarsVars "
-                              f"``{ifile} -rm d_dz_{idiff}''{Nclr}")
+                    except_message(debug,exception,idiff,ifile,pre="d_dz_")
 
         # ==============================================================
         #                       Zonal Detrending
@@ -1780,15 +1764,7 @@ def main():
 
                     print(f"{izdetrend}_p: {Green}Done{Nclr}")
                 except Exception as exception:
-                    if debug:
-                        raise
-                    if str(exception) == (
-                        "NetCDF: String match to name in use"
-                        ):
-                        print(f"{Yellow}***Error*** Variable already "
-                              f"exists in file. Delete the existing "
-                              f"variable d_dz_{idiff} with MarsVars "
-                              f"``{ifile} -rm d_dz_{idiff}``{Nclr}")
+                    except_message(debug,exception,izdetrend,ifile,ext="_p")
 
         # ==============================================================
         #           Opacity Conversion (dp_to_dz and dz_to_dp)
@@ -1829,16 +1805,7 @@ def main():
                     print(f"{idp_to_dz}_dp_to_dz: {Green}Done{Nclr}")
 
                 except Exception as exception:
-                    if debug:
-                        raise
-                    if str(exception) == (
-                        "NetCDF: String match to name in use"
-                        ):
-                        print(f"{Yellow}***Error*** Variable already "
-                              f"exists in file.\nDelete the existing "
-                              f"variable {idp_to_dz}_dp_to_dz with "
-                              f"``MarsVars {ifile} -rm {idp_to_dz}_dp_"
-                              f"to_dz``{Nclr}")
+                    except_message(debug,exception,idp_to_dz,ifile,ext="_dp_to_dz")
 
         for idz_to_dp in dz_to_dp_list:
             # ========= Case 2: dz_to_dp
@@ -1876,16 +1843,7 @@ def main():
                     print(f"{idz_to_dp}_dz_to_dp: {Green}Done{Nclr}")
 
                 except Exception as exception:
-                    if debug:
-                        raise
-                    if str(exception) == (
-                        "NetCDF: String match to name in use"
-                        ):
-                        print(f"{Yellow}***Error*** Variable already "
-                              f"exists in file.\nDelete the existing "
-                              f"variable {idp_to_dz}_dp_to_dz with "
-                              f"``MarsVars {ifile} -rm "
-                              f"{idp_to_dz}_dp_to_dz``{Nclr}")
+                    except_message(debug,exception,idz_to_dp,ifile,ext="_dz_to_dp")
 
         # ==============================================================
         #                    Column Integration
@@ -1964,16 +1922,7 @@ def main():
                     print(f"{icol}_col: {Green}Done{Nclr}")
 
                 except Exception as exception:
-                    if debug:
-                        raise
-                    if str(exception)[0:35] == (
-                        "NetCDF: String match to name in use"):
-                        print(f"{Yellow}***Error*** Variable already "
-                              f"exists in file.\nDelete the existing "
-                              f"variable {icol}_col with ``MarsVars "
-                              f"{ifile} -rm {icol}_col``{Nclr}")
-                    else:
-                        print(f"{Red}***Error*** {str(exception)}")
+                    except_message(debug,exception,icol,ifile,ext="_col")
         if edit_var:
             f_IN = Dataset(ifile, "r", format = "NETCDF4_CLASSIC")
             ifile_tmp = f"{ifile[:-3]}_tmp.nc"


### PR DESCRIPTION
Added a new function "except_message" to Script_utils.
This function accepts the debug flag, variable name, file name, and optional prefix or extension and prints out the help message to remove the variable if the error matches the "already exists" error. Otherwise it prints the exception.