### PR TITLE
Fixed MSF calculation issue

### DIFF
--- a/amescap/FV3_utils.py
+++ b/amescap/FV3_utils.py
@@ -1275,7 +1275,13 @@ def mass_stream(v_avg, lat, level, type="pstd", psfc=700, H=8000.,
             .g. ⌡ f(z)dz = (Zn-Zn-1){f(Zn) + f(Zn-1)}/2
               n-1
     """
-
+    reverting = False
+    if level[0] < level[-1]:
+        reverting = True
+        print("Reversing pstd array for mass stream function calculation...")
+        level = level[::-1]
+        v_avg = v_avg[::-1, ...]
+                    
     g = 3.72 # m/s2
     a = 3400*1000 # m
     nlev = len(level)
@@ -1335,6 +1341,11 @@ def mass_stream(v_avg, lat, level, type="pstd", psfc=700, H=8000.,
         MSF[mask] = np.nan
     if isMasked:
         MSF = np.ma.array(MSF, mask = mask)
+    
+    if reverting:
+        print("Reversing pstd dimension of MSF array for compatibility...")
+        MSF = MSF[::-1, ...]
+        
     return MSF.reshape(shape_out)
 
 

--- a/amescap/Script_utils.py
+++ b/amescap/Script_utils.py
@@ -928,7 +928,6 @@ def filter_vars(fNcdf, include_list=None, giveExclude=False):
         else:
             print(f"{Yellow}***Warning*** from filter_vars(): "
                   f"{ivar} not found in file.\n")
-            exit()
 
     baseline_var = []
     for ivar in  var_list:

--- a/bin/MarsInterp.py
+++ b/bin/MarsInterp.py
@@ -499,8 +499,6 @@ def main():
 
                 long_name_txt = getattr(fNcdf.variables[ivar], "long_name", "")
                 units_txt = getattr(fNcdf.variables[ivar], "units", "")
-                # long_name_txt=fNcdf.variables[ivar].long_name
-                # units_txt=fNcdf.variables[ivar].units)
 
                 if not do_diurn:
                     if "tile" in ifile:
@@ -538,13 +536,18 @@ def main():
                             fnew.copy_Ncaxis_with_content(fNcdf.variables[ivar])
                         else:
                             fnew.copy_Ncvar(fNcdf.variables[ivar])
-
+                            
+        with Dataset(newname, 'r') as nc_file:
+            # Print the global attributes of the NetCDF file
+            print(f"\nGlobal File Attributes for {newname}:")
+            for attr_name in nc_file.ncattrs():
+                print(f"  {attr_name}: {getattr(nc_file, attr_name)}")
+            
         print("\r ", end="")
         fNcdf.close()
         fnew.close()
         print(f"Completed in {(time.time() - start_time):3f} sec")
-
-
+                
 # ======================================================================
 #                           END OF PROGRAM
 # ======================================================================

--- a/bin/MarsVars.py
+++ b/bin/MarsVars.py
@@ -311,7 +311,7 @@ master_list = {
     'msf': [
         "Mass stream function",
         '1.e8 kg/s',
-        ['vcomp'],
+        ['vcomp', 'temp'],
         ['pstd', 'zstd', 'zagl']
     ],
     'mx': [


### PR DESCRIPTION
if the pstd dimension values are not in decreasing order (e.g., bottom to top of atmosphere), then the MSF calculation gets wonky. MarsInterp ensures the pstd dimension is decreasing, but if pressure interpolation is done outside CAP (e.g., with runpinterp.csh released with the NASA Ames Mars GCM) and the pstd dimension values are in increasing order, the MSF calculation is wrong. This bug fix checks the pstd order in mass_stream, calculates MSF properly, then puts the pstd back in the order it started with. In other words, this fix preserves the original order of values in pstd, only reversing it for the math.